### PR TITLE
Improve description in README.md and provide scripts to download server and example traces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ pack/
 trace-compass-server
 trace-compass-server.tar.gz
 
+# sample traces
+TraceCompassTutorialTraces
+TraceCompassTutorialTraces.tgz
+
 # misc
 .DS_Store
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ coverage/
 lib/
 pack/
 
+# trace server
+trace-compass-server
+trace-compass-server.tar.gz
+
 # misc
 .DS_Store
 .env.local

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # VSCode Trace Extension
 
-This project started from the [vscode webview react project](https://github.com/rebornix/vscode-webview-react). It works this way, with the extension itself being in the `vscode-trace-extension` directory and the react application being in the `vscode-trace-webapps` directory.
+This project started from the [vscode webview react project][vscode-webview-react]. It works this way, with the extension itself being in the `vscode-trace-extension` directory and the react application being in the `vscode-trace-webapps` directory.
 
 ## Installation instructions
 
-The code was migrated from the [PR in theia-trace-extension](https://github.com/theia-ide/theia-trace-extension/pull/124)
+The code was migrated from the [PR in theia-trace-extension][init-contrib].
 
-It depends on the trace viewer plugins from the [theia trace extension package](https://github.com/theia-ide/theia-trace-extension/) and the [tsp typescript client](https://github.com/theia-ide/tsp-typescript-client/). They are all available from the NPM package registry.  
+It depends on the trace viewer plugins from the [theia trace extension package][theia-trace] and the [tsp typescript client][tsp-client]. They are all available from the NPM package registry.  
 
 - traceviewer-base
 - traceviewer-react-components
@@ -28,40 +28,36 @@ Open the `Trace Viewer` view (`View` -> `Open view...`).
 
 ![open-trace](https://raw.githubusercontent.com/theia-ide/vscode-trace-extension/master/doc/images/vscode-open-with-trace-viewer-001.png)
 
-2 tabs will be visible: `Traces` and `Views`. The `Traces` tab will show all available traces on the trace server. 
+2 tabs will be visible: `Traces` and `Views`. The `Traces` tab will show all available traces on the trace server.
 
 The `Views` tab shows all the available views for the selected trace. Click on a view to open the view under the timeline.
 
 ![open-output](https://raw.githubusercontent.com/theia-ide/vscode-trace-extension/master/doc/images/vscode-trace-extension-001.png)
 
-## Running the extension in Theia
+## Package as VsCode extension
 
-To get this extension running in a theia environment, it should first be packaged as an extension by running `yarn vsce:package`. If you get errors about case-sensitive files, just delete the node_modules folder and run `yarn` again, then make sure all the trace extension packages are symlinked.
+To package it as VsCode extension, run the command `yarn vsce:package`. If you get errors about case-sensitive files, just delete the node_modules folder and run `yarn` again.
 
 The packaging will produce a `vscode-trace-extension-x.x.x.vsix` file in the subdirectory `vscode-trace-extension` of the repo.
 
-This file can be symlinked in the theia-trace-extension example app's plugins folder
+## Running the extension in VsCode, VsCodium or Theia application
+
+The packaged VSIX file can be installed in an existing `VsCode`, `VsCodium` or `Theia` application by using [Install from a vsix][install].
+
+The trace server needs to be started separately as described [here](#run-the-trace-server).
+
+## Running the extension in the Theia Trace Viewer example app
+
+The packaged VSIX file can be run in the example app of the [theia-trace-extension][theia-trace]. For this the file can be can be symlinked in the `plugins` of the example app of `theia-trace-extension` repo.
 
 ``` bash
 cd <theia-trace-extension root>/examples/plugins
 ln -s <vscode-trace-extension root>/vscode-trace-extension-x.x.x.vsix ./
 ```
 
-Then, again, in order to avoid problems with the Webview, cross domain and the trace server, the **theia server should be run with SSL**, so one can add a script like this in the `<theia-trace-extension>/examples/browser/package.json` file:
+## Developing the extension
 
-``` bash
-"start:ssl": "theia start --ssl --cert /path/to/cert.pem --certkey /path/to/privkey.pem --plugins=local-dir:../plugins",
-```
-
-which is a variation on the `start` script, with the `--ssl` parameter and path to the certificate and key.
-
-This also requires the **trace server to run using SSL**. See the instructions [to run the trace server with SSL](https://github.com/tracecompass/tracecompass-incubator/tree/master/trace-server#run-the-server-with-ssl).
-
-***Current status***: Not working because there is no way to link to the user's trace open command. In the theia-trace-extension, trace opening has specific steps and commands so the vscode extension can't hook to them and it doesn't use the default file opening scheme of vscode that the extension can hook to. Also, there are runtime errors about missing packages `@trace-viewer/base`. Is it related to the plugins not being published? Or is it linked to the symlinked module when building vscode?
-
-## Developping the extension
-
-When having to modify the code of the extension (in the `vscode-trace-extension` folder), on can simply run the `yarn` command. It is also possible to watch for changes to have no manual steps to do before re-running the extension: `yarn watch` or `ctrl-shift-b` and select the task `npm: watch - vscode-trace-extension`.
+When having to modify the code of the extension (in the `vscode-trace-extension` folder), one can simply run the `yarn` command. It is also possible to watch for changes to have no manual steps to do before re-running the extension: `yarn watch` or `ctrl-shift-b` and select the task `npm: watch - vscode-trace-extension`.
 
 For changes in the webview part (in the `vscode-trace-webviews` folder), you can run the `yarn` command, simply re-opening a trace should show the changes. It is also possible to watch for changes with `yarn watch` or `ctrl-shift-b` and selecting the task `npm: watch - vscode-trace-webviews`.
 
@@ -71,7 +67,7 @@ It is straightforward to debug the code of the vscode extension itself (the code
 
 The react-app is another matter. The panel is a webview that is running in its own context, so current vscode does not have access to it. _(Patches welcome!)_
 
-Each panel is its own small web application, so to debug, while in the context of the webview, press `ctrl-shift-p` and entre the command `Developer: Open Webview Developer Tools`. This will open the developer tools. The code is in the `Sources` tab of the developer tools window that opens.
+Each panel is its own small web application, so to debug, while in the context of the webview, press `ctrl-shift-p` and enter the command `Developer: Open Webview Developer Tools`. This will open the developer tools. The code is in the `Sources` tab of the developer tools window that opens.
 
 ### Troubleshooting
 
@@ -81,7 +77,6 @@ Right-click on the vscode activity bar and make sure `Trace Viewer` is checked.
 
 ![trace-explorer-activity-bar](https://raw.githubusercontent.com/theia-ide/vscode-trace-extension/master/doc/images/vscode-show-trace-viewer-001.png)
 
-*It is still a prototype, don't try anything fancy.*
 
 ## Run the Trace Server
 
@@ -102,5 +97,10 @@ To get sample traces to try run the following command. The traces will be stored
 yarn download:sample-traces
 ```
 
+[init-contrib]: https://github.com/theia-ide/theia-trace-extension/pull/124
+[install]: https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix
+[theia-trace]: https://github.com/theia-ide/theia-trace-extension/
 [tc-server]: https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d
 [tc-server-build]: https://www.eclipse.org/tracecompass/download.html#trace-server
+[tsp-client]: https://github.com/theia-ide/tsp-typescript-client/
+[vscode-webview-react]: https://github.com/rebornix/vscode-webview-react

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ It depends on the trace viewer plugins from the [theia trace extension package](
 
 To build the vscode extension, run the `yarn` command:
 
-```
+``` bash
 yarn
 ```
 
 ## Running the extension
 
-Then from vscode, press `f5` to run the extension.
+Then from vscode, press `f5` to run the extension. The trace server needs to be started separately as described [here](#run-the-trace-server).
 
-To open a trace use the VSCode file explorer to navigate to the trace directory. Then right mouse click on the trace and select menu option `Open with Trace Viewer`. 
+To open a trace use the VSCode file explorer to navigate to the trace directory. Then right mouse click on the trace and select menu option `Open with Trace Viewer`.
 
 Open the `Trace Viewer` view (`View` -> `Open view...`).
 
@@ -38,18 +38,18 @@ The `Views` tab shows all the available views for the selected trace. Click on a
 
 To get this extension running in a theia environment, it should first be packaged as an extension by running `yarn vsce:package`. If you get errors about case-sensitive files, just delete the node_modules folder and run `yarn` again, then make sure all the trace extension packages are symlinked.
 
-The packaging will produce a `vscode-trace-extension-x.x.x.vsix` file in the root of the repo.
+The packaging will produce a `vscode-trace-extension-x.x.x.vsix` file in the subdirectory `vscode-trace-extension` of the repo.
 
 This file can be symlinked in the theia-trace-extension example app's plugins folder
 
-```
+``` bash
 cd <theia-trace-extension root>/examples/plugins
 ln -s <vscode-trace-extension root>/vscode-trace-extension-x.x.x.vsix ./
 ```
 
 Then, again, in order to avoid problems with the Webview, cross domain and the trace server, the **theia server should be run with SSL**, so one can add a script like this in the `<theia-trace-extension>/examples/browser/package.json` file:
 
-```
+``` bash
 "start:ssl": "theia start --ssl --cert /path/to/cert.pem --certkey /path/to/privkey.pem --plugins=local-dir:../plugins",
 ```
 
@@ -69,17 +69,30 @@ For changes in the webview part (in the `vscode-trace-webviews` folder), you can
 
 It is straightforward to debug the code of the vscode extension itself (the code in `vscode-trace-extension`) by just putting breakpoints in vscode and running the extension with `f5`.
 
-The react-app is another matter. The panel is a webview that is running in its own context, so current vscode does not have access to it. _(Patches welcome!)_ 
+The react-app is another matter. The panel is a webview that is running in its own context, so current vscode does not have access to it. _(Patches welcome!)_
 
 Each panel is its own small web application, so to debug, while in the context of the webview, press `ctrl-shift-p` and entre the command `Developer: Open Webview Developer Tools`. This will open the developer tools. The code is in the `Sources` tab of the developer tools window that opens.
 
 ### Troubleshooting
 
- * The `Trace Viewer` panel is not there, or disappears when switching panel.
+*The `Trace Viewer` panel is not there, or disappears when switching panel.
 
 Right-click on the vscode activity bar and make sure `Trace Viewer` is checked.
 
 ![trace-explorer-activity-bar](https://raw.githubusercontent.com/theia-ide/vscode-trace-extension/master/doc/images/vscode-show-trace-viewer-001.png)
 
-_It is still a prototype, don't try anything fancy._
+*It is still a prototype, don't try anything fancy.*
 
+## Run the Trace Server
+
+In order to open traces, you need a trace server running on the same machine as the trace extension. You can download the [Eclipse Trace Compass server][tc-server] or let `yarn` download and run it:
+
+```bash
+yarn download:server
+yarn start:server
+```
+
+You can also build the trace-server yourself using Trace Compass and the Incubator. Take a look at the [instructions here][tc-server-build].
+
+[tc-server]: https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d
+[tc-server-build]: https://www.eclipse.org/tracecompass/download.html#trace-server

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn
 
 Then from vscode, press `f5` to run the extension. The trace server needs to be started separately as described [here](#run-the-trace-server).
 
-To open a trace use the VSCode file explorer to navigate to the trace directory. Then right mouse click on the trace and select menu option `Open with Trace Viewer`.
+To open a trace use the VSCode file explorer to navigate to the trace directory. Then right mouse click on the trace and select menu option `Open with Trace Viewer`. See [here](get-sample-traces) to get some sample traces.
 
 Open the `Trace Viewer` view (`View` -> `Open view...`).
 
@@ -93,6 +93,14 @@ yarn start:server
 ```
 
 You can also build the trace-server yourself using Trace Compass and the Incubator. Take a look at the [instructions here][tc-server-build].
+
+## Get sample traces
+
+To get sample traces to try run the following command. The traces will be stored under the subdirectory `TraceCompassTutorialTraces` of the repo.
+
+```bash
+yarn download:sample-traces
+```
 
 [tc-server]: https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d
 [tc-server-build]: https://www.eclipse.org/tracecompass/download.html#trace-server

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "watch": "lerna run watch",
   "clean": "lerna run clean",
   "vsce:package": "lerna run vsce:package",
-  "lint": "lerna run lint"
+  "lint": "lerna run lint",
+  "download:server": "curl -o trace-compass-server.tar.gz https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/trace-compass-server-latest-linux.gtk.x86_64.tar.gz; tar -xf trace-compass-server.tar.gz",
+  "start:server": "./trace-compass-server/tracecompass-server"
   },
   "devDependencies": {
     "lerna": "^3.20.2"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "vsce:package": "lerna run vsce:package",
   "lint": "lerna run lint",
   "download:server": "curl -o trace-compass-server.tar.gz https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/trace-compass-server-latest-linux.gtk.x86_64.tar.gz; tar -xf trace-compass-server.tar.gz",
-  "start:server": "./trace-compass-server/tracecompass-server"
+  "start:server": "./trace-compass-server/tracecompass-server",
+  "download:sample-traces": "curl -o TraceCompassTutorialTraces.tgz https://raw.githubusercontent.com/dorsal-lab/tracevizlab/master/labs/TraceCompassTutorialTraces.tgz; tar -xf TraceCompassTutorialTraces.tgz"
   },
   "devDependencies": {
     "lerna": "^3.20.2"


### PR DESCRIPTION
- Add script in package.json to download and run Trace Compass server
- Add script in package.json to download sample traces
- General clean-up of README.md and for how to run the extension
   - Remove SSL requirement description in README for running in Theia
   - Better explain packaging and how to run the extension
   - Fix typos and linting errors
-  Provide details about webviews and their communication to the README.md
   - Provide a sequence diagram illustrating the communication between 2 webviews.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>
